### PR TITLE
Use github_api_token secret for interact server

### DIFF
--- a/roles/interact/defaults/main.yml
+++ b/roles/interact/defaults/main.yml
@@ -3,5 +3,12 @@
 # to get an API key from JupyterHub
 jupyterhub_admin_user: ''
 
+# API token to access private repos on github.com/data-8
+github_api_token: ''
+
+# Base URL for the deployment eg. ds8.berkeley.edu . Don't include the protocol
+# or a trailing slash.
+base_url: ''
+
 # Needed to make sure the API version matches with docker-py
 docker_api_version: 1.16

--- a/roles/interact/tasks/main.yml
+++ b/roles/interact/tasks/main.yml
@@ -5,6 +5,9 @@
 - fail: msg="github_api_token is not defined"
   when: github_api_token == ''
 
+- fail: msg="base_url is not defined"
+  when: base_url == ''
+
 - name: install daemon for interact
   apt: update_cache=yes cache_valid_time=600 name=daemon state=latest
   sudo: yes
@@ -54,7 +57,8 @@
 - name: start interact
   command: >
     env JPY_API_TOKEN={{ jpy_api_token.stdout }}
-    env GITHUB_API_TOKEN={{ github_api_token }}
+        GITHUB_API_TOKEN={{ github_api_token }}
+        BASE_URL={{ base_url }}
     daemon -n interact -o /var/log/interact.log --chdir=/srv --
       python3 /srv/interact/run.py --production
   sudo: yes

--- a/roles/interact/tasks/main.yml
+++ b/roles/interact/tasks/main.yml
@@ -2,6 +2,9 @@
 - fail: msg="jupyterhub_admin_user is not defined"
   when: jupyterhub_admin_user == ''
 
+- fail: msg="github_api_token is not defined"
+  when: github_api_token == ''
+
 - name: install daemon for interact
   apt: update_cache=yes cache_valid_time=600 name=daemon state=latest
   sudo: yes
@@ -49,7 +52,11 @@
     - rebuild-interact
 
 - name: start interact
-  command: env JPY_API_TOKEN={{ jpy_api_token.stdout }} daemon -n interact -o /var/log/interact.log --chdir=/srv -- python3 /srv/interact/run.py --production
+  command: >
+    env JPY_API_TOKEN={{ jpy_api_token.stdout }}
+    env GITHUB_API_TOKEN={{ github_api_token }}
+    daemon -n interact -o /var/log/interact.log --chdir=/srv --
+      python3 /srv/interact/run.py --production
   sudo: yes
   tags:
     - rebuild-interact

--- a/secrets.vault.yml.example
+++ b/secrets.vault.yml.example
@@ -45,10 +45,11 @@ oauth_callback_url: ''
 # Overwritten cull/stats variables (see the cull and stats roles for details)
 jupyterhub_admin_user: ''
 
-# Base URL for the deployment eg. https://ds8.berkeley.edu
-# Used to configure the interact server
+# Base URL for the deployment eg. ds8.berkeley.edu . Don't include the protocol
+# or a trailing slash.
+# Used to configure the interact server.
 base_url: ''
 
 # API token to access private repos on github.com/data-8
-# Used by the interact server
+# Used by the interact server.
 github_api_token: ''

--- a/secrets.vault.yml.example
+++ b/secrets.vault.yml.example
@@ -44,3 +44,7 @@ oauth_callback_url: ''
 
 # Overwritten cull/stats variables (see the cull and stats roles for details)
 jupyterhub_admin_user: ''
+
+# API token to access private repos on github.com/data-8
+# Used by the interact server
+github_api_token: ''

--- a/secrets.vault.yml.example
+++ b/secrets.vault.yml.example
@@ -45,6 +45,10 @@ oauth_callback_url: ''
 # Overwritten cull/stats variables (see the cull and stats roles for details)
 jupyterhub_admin_user: ''
 
+# Base URL for the deployment eg. https://ds8.berkeley.edu
+# Used to configure the interact server
+base_url: ''
+
 # API token to access private repos on github.com/data-8
 # Used by the interact server
 github_api_token: ''


### PR DESCRIPTION
This is a token on my Github account (I filled in secrets.vault.yml on ds8 and
data8). This will allow the interact server to pull from private repos.

Wanted to use a PR to run this by you first to confirm that I can pull
from `master` on ds8 and `azure` on data8 (?) after this is merged into
both branches.

@ryanlovett