### PR TITLE
Add nginx metrics for datadog

### DIFF
--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -82,6 +82,18 @@
   tags:
     - rebuild-proxy
 
+- name: Ensure /usr/share/datadog/agent/dogstream dir exists
+  file: path=/usr/share/datadog/agent/dogstream state=directory
+  sudo: yes
+  tags:
+    - rebuild-proxy
+
+- name: Copy nginx_parser.py
+  template: src=nginx_parser.py dest=/usr/share/datadog/agent/dogstream/nginx_parser.py mode=0644
+  sudo: yes
+  tags:
+    - rebuild-proxy
+
 - name: copy the Dockerfile to the nginx configuration directory
   template: src=Dockerfile.j2 dest={{ nginx_config_dir }}/Dockerfile mode=0644
   sudo: yes

--- a/roles/proxy/templates/nginx.conf.j2
+++ b/roles/proxy/templates/nginx.conf.j2
@@ -11,6 +11,8 @@ http {
 	include /etc/nginx/mime.types;
 	default_type application/octet-stream;
 
+	log_format time_log '$time_local "$request" S=$status $bytes_sent T=$request_time R=$http_x_forwarded_for';
+
     server {
         listen 80;
         server_name {{ inventory_hostname }};
@@ -40,7 +42,7 @@ http {
 
         # Expose logs to "docker logs".
         # See https://github.com/nginxinc/docker-nginx/blob/master/Dockerfile#L12-L14
-        access_log /var/log/nginx/access.log;
+        access_log /var/log/nginx/access.log time_log;
         error_log /var/log/nginx/error.log;
 
         location ~ /hub/static/custom/(.*) {

--- a/roles/proxy/templates/nginx.conf.j2
+++ b/roles/proxy/templates/nginx.conf.j2
@@ -103,6 +103,14 @@ http {
             proxy_set_header Connection "upgrade";
             proxy_read_timeout 86400;
         }
+	
+	location /nginx_status {
+            # Turn on nginx status page
+            stub_status on;
+
+            # Do not log access queries for status page
+            access_log   off;
+  	 }	
 
 	# Why is this happening now ; pre-0.4.1
 	#rewrite ^/hub/login /hub/oauth_login last;

--- a/roles/proxy/templates/nginx_parser.py
+++ b/roles/proxy/templates/nginx_parser.py
@@ -1,0 +1,73 @@
+ustom parser for nginx log suitable for use by Datadog 'dogstreams'.
+To use, add to datadog.conf as follows:
+    dogstreams: [path to ngnix log (e.g: "/var/log/nginx/access.log"]:[path to this python script (e.g "/usr/share/datadog/agent/dogstream/nginx.py")]:[name of parsing method of this file ("parse")]
+so, an example line would be:
+    dogstreams: /var/log/nginx/access.log:/usr/share/datadog/agent/dogstream/nginx.py:parse
+Log of nginx should be defined like that:
+    log_format time_log '$time_local "$request" S=$status $bytes_sent T=$request_time R=$http_x_forwarded_for';
+when starting dd-agent, you can find the collector.log and check if the dogstream initialized successfully
+    """
+from datetime import datetime
+import time
+import re
+
+# mapping between datadog and supervisord log levels
+METRIC_TYPES = {
+    'AVERAGE_RESPONSE': 'nginx.net.avg_response',
+    'FIVE_HUNDRED_STATUS': 'nginx.net.5xx_status',
+    'FOUR_HUNDRED_STATUS': 'nginx.net.4xx_status'
+}
+
+TIME_REGEX = "\sT=[-+]?[0-9]*\.?[0-9]+\s*"
+TIME_REGEX_SPLIT = re.compile("T=")
+FOUR_HUNDRED_STATUS_REGEX = "\sS=+4[0-9]{2}\s"
+FIVE_HUNDRED_STATUS_REGEX = "\sS=+5[0-9]{2}\s"
+
+def parse(log, line):
+    if len(line) == 0:
+        log.info("Skipping empty line")
+        return None
+    timestamp = getTimestamp(line)
+    avgTime = parseAvgTime(line)
+    objToReturn = []
+    if isHttpResponse5XX(line):
+        objToReturn.append((METRIC_TYPES['FIVE_HUNDRED_STATUS'], timestamp, 1, {'metric_type': 'counter'}))
+    if isHttpResponse4XX(line):
+        objToReturn.append((METRIC_TYPES['FOUR_HUNDRED_STATUS'], timestamp, 1, {'metric_type': 'counter'}))
+    if avgTime is not None:
+        objToReturn.append((METRIC_TYPES['AVERAGE_RESPONSE'], timestamp, avgTime, {'metric_type': 'gauge'}))
+    return objToReturn
+
+def getTimestamp(line):
+    line_parts = line.split()
+    dt = line_parts[0]
+    date = datetime.strptime(dt, "%d/%b/%Y:%H:%M:%S")
+    date = time.mktime(date.timetuple())
+    return date
+
+def parseAvgTime(line):
+    time = re.search(TIME_REGEX, line)
+    if time is not None:
+        time = time.group(0)∫
+        time = TIME_REGEX_SPLIT.split(time)
+        if len(time) == 2:
+            return float(time[1])
+        return None
+
+def isHttpResponse5XX(line):
+    response = re.search(FIVE_HUNDRED_STATUS_REGEX, line)
+    return (response is not None)
+
+def isHttpResponse4XX(line):
+    response = re.search(FOUR_HUNDRED_STATUS_REGEX, line)
+    return (response is not None)
+
+if __name__ == "__main__":
+    import sys
+    import pprint
+    import logging
+    logging.basicConfig()
+    log = logging.getLogger()
+    lines = open(sys.argv[1]).readlines()
+    pprint.pprint([parse(log, line) for line in lines])
+

--- a/roles/proxy/templates/nginx_parser.py
+++ b/roles/proxy/templates/nginx_parser.py
@@ -1,4 +1,5 @@
-ustom parser for nginx log suitable for use by Datadog 'dogstreams'.
+"""
+Custom parser for nginx log suitable for use by Datadog 'dogstreams'.
 To use, add to datadog.conf as follows:
     dogstreams: [path to ngnix log (e.g: "/var/log/nginx/access.log"]:[path to this python script (e.g "/usr/share/datadog/agent/dogstream/nginx.py")]:[name of parsing method of this file ("parse")]
 so, an example line would be:
@@ -6,7 +7,8 @@ so, an example line would be:
 Log of nginx should be defined like that:
     log_format time_log '$time_local "$request" S=$status $bytes_sent T=$request_time R=$http_x_forwarded_for';
 when starting dd-agent, you can find the collector.log and check if the dogstream initialized successfully
-    """
+"""
+
 from datetime import datetime
 import time
 import re


### PR DESCRIPTION
This PR add basic activity, error, and performance metrics to nginx. There are additional manual steps that need to be done

**Additional steps for basic activity metrics:**
Step 1: Edit `/etc/dd-agent/conf.d/nginx.yaml` in the proxy node

```
init_config:

instances:
  # For every instance, you need an `nginx_status_url` and can optionally
  # supply a list of tags.  This plugin requires nginx to be compiled with
  # the nginx stub status module option, and activated with the correct
  # configuration stanza.  On debian/ubuntu, this is included in the
  # `nginx-extras` package.  For more details, see:
  #
  #   http://docs.datadoghq.com/integrations/nginx/
  #

    -   nginx_status_url: <REPLACE_WITH_ROOT_URL>/nginx_status
        ssl_validation: False
        tags:
            -   instance:derrick_proxy
```

Step 2: Restart agent
- sudo /etc/init.d/datadog-agent restart

**Additional steps needed to get error and performance metrics running on datadog:**
Step 1: Ensure that /var/log/nginx/access.log exist, else create an empty file
Step 2: Run `docker logs -f nginx > /var/log/nginx/access.log &` if the process doesn't exist
Step 3: Add this line to /etc/dd-agent
- /var/log/nginx/access.log:/usr/share/datadog/agent/dogstream/nginx.py:parse
  Step 4: Restart agent
- sudo /etc/init.d/datadog-agent restart
